### PR TITLE
Added basic namespace support using Ox

### DIFF
--- a/lib/openxml/builder.rb
+++ b/lib/openxml/builder.rb
@@ -4,41 +4,78 @@
 #
 # This class mimics the XML Builder DSL.
 require "ox"
+require "openxml/builder/element"
+require "openxml/builder/namespace"
 
 module OpenXml
   class Builder
+    attr_reader :parent
 
-    def initialize
-      @document = Ox::Document.new(version: "1.0")
-      @current = @document
+    def initialize(options={})
+      @options = {
+        with_xml: true,
+        encoding: "utf-8"
+      }.merge(options)
+      @options[:with_xml] = !!@options[:with_xml] || @options[:standalone] == :yes
+
+      @document = Ox::Document.new({version: "1.0"}.merge(@options))
+      @parent = @document
       yield self if block_given?
     end
 
     def to_s
-      Ox.dump @document
+      Ox.dump @document, @options
     end
     alias :to_xml :to_s
 
+    # Adapted from Nokogiri's builder.rb
+    def [](ns)
+      if @parent != @document
+        @ns = @parent.namespace_definitions.find { |x| x.prefix == ns.to_s }
+      end
+      return self if @ns
+
+      @parent.ancestors.each do |a|
+        next if a == @document
+        @ns = a.namespace_definitions.find { |x| x.prefix == ns.to_s }
+        return self if @ns
+      end
+
+      @ns = { :pending => ns.to_s }
+      return self
+    end
+
     def method_missing(tag_name, *args)
-      new_element = Ox::Element.new(tag_name)
+      new_element = OpenXml::Builder::Element.new(tag_name)
+      new_element.parent = @parent
       attributes = extract_options!(args)
       attributes.each do |key, value|
         new_element[key] = value
       end
 
+      # Adapted from Nokogiri's builder.rb
+      if @ns.is_a? OpenXml::Builder::Namespace
+        new_element.namespace = @ns
+      elsif @ns.is_a? Hash
+        new_element.namespace = new_element.namespace_definitions.find { |x| x.prefix == @ns[:pending] }
+        raise ArgumentError, "Namespace #{@ns[:pending]} has not been defined" if new_element.namespace.nil?
+      end
+
+      @ns = nil
+
       if block_given?
         begin
-          was_current = @current
-          @current = new_element
+          was_current = @parent
+          @parent = new_element
           yield self
         ensure
-          @current = was_current
+          @parent = was_current
         end
       elsif value = args.first
         new_element << value.to_s
       end
 
-      @current << new_element
+      @parent << new_element.__getobj__
     end
 
   private

--- a/lib/openxml/builder/element.rb
+++ b/lib/openxml/builder/element.rb
@@ -1,0 +1,43 @@
+module OpenXml
+  class Builder
+    class Element < SimpleDelegator
+      attr_reader :namespace
+      attr_accessor :parent
+
+      def initialize(*args)
+        super Ox::Element.new(*args)
+      end
+
+      def []=(attribute, value)
+        namespace_def = attribute.downcase.to_s.match /^xmlns(?:\:(?<prefix>.*))?$/
+        add_namespace(namespace_def[:prefix], value.to_s) if namespace_def
+        super
+      end
+
+      def namespace=(ns)
+        @namespace = ns
+        tag = name.match(/^(?:\w*?\:)?(?<tag>\w*)$/i)[:tag]
+        self.value = "#{namespace.prefix}:#{tag}" if namespace.is_a? OpenXml::Builder::Namespace
+        self.value = "#{namespace}:#{tag}" if namespace.is_a? String
+      end
+
+      def namespaces
+        @namespaces ||= []
+      end
+      alias :namespace_definitions :namespaces
+
+      def ancestors
+        parents = [self]
+        parents << parent.ancestors unless parent.nil? || !parent.respond_to?(:ancestors)
+        parents.flatten
+      end
+
+    private
+
+      def add_namespace(prefix, uri)
+        namespaces << OpenXml::Builder::Namespace.new(prefix, uri)
+      end
+
+    end
+  end
+end

--- a/lib/openxml/builder/namespace.rb
+++ b/lib/openxml/builder/namespace.rb
@@ -1,0 +1,13 @@
+module OpenXml
+  class Builder
+    class Namespace
+      attr_accessor :prefix, :uri
+
+      def initialize(prefix, uri)
+        @prefix = prefix.to_s
+        @uri = uri
+      end
+
+    end
+  end
+end

--- a/lib/openxml/part.rb
+++ b/lib/openxml/part.rb
@@ -1,16 +1,14 @@
-require "nokogiri"
 require "openxml/builder"
 
 module OpenXml
   class Part
-    include ::Nokogiri
 
-    def build_xml
-      OpenXml::Builder.new { |xml| yield xml }.to_xml
+    def build_xml(options={})
+      OpenXml::Builder.new(options) { |xml| yield xml }.to_xml
     end
 
     def build_standalone_xml(&block)
-      "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" + build_xml(&block)
+      build_xml({ standalone: :yes }, &block)
     end
 
     def read

--- a/test/part_test.rb
+++ b/test/part_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+require "fileutils"
+require "set"
+
+class OpenXmlPartTest < ActiveSupport::TestCase
+  attr_reader :part, :builder
+
+
+
+  context "Building" do
+    setup do
+      @part = OpenXml::Part.new
+    end
+
+    context "Given simple xml for one part" do
+      setup do
+        @builder = @part.build_xml do |xml|
+          xml.document do |xml|
+            2.times { xml.child({ attribute: "value", other_attr: "other value" }) }
+          end
+        end
+      end
+
+      should "build the expected xml" do
+        assert_equal basic_xml, builder.to_s
+      end
+    end
+
+    context "Given namespaced xml for one part" do
+      setup do
+        @builder = @part.build_xml do |xml|
+          xml.document({ "xmlns:ns" => "some:namespace:uri" }) do
+            2.times { xml["ns"].child({ attribute: "value", other_attr: "other value" }) }
+          end
+        end
+      end
+
+      should "build the expected xml" do
+        assert_equal namespaced_xml, builder.to_s
+      end
+    end
+
+  end
+
+
+
+private
+
+
+  def basic_xml
+    <<-STR
+<?xml version="1.0" encoding="utf-8"?>
+<document>
+  <child attribute="value" other_attr="other value"/>
+  <child attribute="value" other_attr="other value"/>
+</document>
+    STR
+  end
+
+  def namespaced_xml
+    <<-STR
+<?xml version="1.0" encoding="utf-8"?>
+<document xmlns:ns="some:namespace:uri">
+  <ns:child attribute="value" other_attr="other value"/>
+  <ns:child attribute="value" other_attr="other value"/>
+</document>
+    STR
+  end
+
+
+end


### PR DESCRIPTION
Extends `Ox::Node` to have a concept of parent and `Ox::HasAttrs` to include the idea of namespaces. `OpenXml::Builder` has been modified to implement the same sort of DSL as Nokogiri's builder class with regards to namespaces.