### PR TITLE
Wrapped Ox::Document to allow for namespaced root elements

### DIFF
--- a/lib/openxml/builder.rb
+++ b/lib/openxml/builder.rb
@@ -4,6 +4,7 @@
 #
 # This class mimics the XML Builder DSL.
 require "ox"
+require "openxml/builder/document"
 require "openxml/builder/element"
 require "openxml/builder/namespace"
 
@@ -18,13 +19,13 @@ module OpenXml
       }.merge(options)
       @options[:with_xml] = !!@options[:with_xml] || @options[:standalone] == :yes
 
-      @document = Ox::Document.new({version: "1.0"}.merge(@options))
+      @document = OpenXml::Builder::Document.new({version: "1.0"}.merge(@options))
       @parent = @document
       yield self if block_given?
     end
 
     def to_s
-      Ox.dump @document, @options
+      Ox.dump @document.__getobj__, @options
     end
     alias :to_xml :to_s
 

--- a/lib/openxml/builder/document.rb
+++ b/lib/openxml/builder/document.rb
@@ -1,0 +1,15 @@
+module OpenXml
+  class Builder
+    class Document < SimpleDelegator
+
+      def initialize(*args)
+        super Ox::Document.new(*args)
+      end
+
+      def ancestors
+        [self]
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
When using the builder, it was impossible for the root element of an xml document to have a namespace prefix, since `Ox::Document` didn't respond to `ancestors`. Therefore, I wrapped `Ox::Document` in a SimpleDelegator subclass and added the `ancestors` method.

Now, this is possible:
```ruby
build_xml do |xml|
  xml["w"].hdr(root_namespaces) {
    ...
  }
end
```

Resulting in:
```xml
<?xml version="1.0"?>
<w:hdr xmlns:w="...">
  ...
</w:hdr>
```