### PR TITLE
Use Correct Syntax for Nokogiri Parsing

### DIFF
--- a/lib/openxml/parts/content_types.rb
+++ b/lib/openxml/parts/content_types.rb
@@ -1,3 +1,5 @@
+require "nokogiri"
+
 module OpenXml
   module Parts
     class ContentTypes < OpenXml::Part
@@ -9,7 +11,7 @@ module OpenXml
       }.freeze
 
       def self.parse(xml)
-        document = Nokogiri(xml)
+        document = Nokogiri::XML(xml)
         self.new.tap do |part|
           document.css("Default").each do |default|
             part.add_default default["Extension"], default["ContentType"]


### PR DESCRIPTION
This pull request uses the correct syntax for parsing XML documents with Nokogiri.

See http://www.nokogiri.org/tutorials/parsing_an_html_xml_document.html

A consequence is that this allows the Package.read method to work properly.