### PR TITLE
Use Correct Syntax for Nokogiri Parsing

### DIFF
--- a/lib/openxml/parts/rels.rb
+++ b/lib/openxml/parts/rels.rb
@@ -1,4 +1,5 @@
 require "securerandom"
+require "nokogiri"
 
 module OpenXml
   module Parts
@@ -6,7 +7,7 @@ module OpenXml
       include Enumerable
 
       def self.parse(xml)
-        document = Nokogiri(xml)
+        document = Nokogiri::XML(xml)
         self.new.tap do |part|
           document.css("Relationship").each do |rel|
             part.add_relationship rel["Type"], rel["Target"], rel["Id"], rel["TargetMode"]


### PR DESCRIPTION
This pull request uses the correct syntax for parsing XML documents with Nokogiri.

See http://www.nokogiri.org/tutorials/parsing_an_html_xml_document.html