### PR TITLE
Fix issue with global content types stepping on each other

### DIFF
--- a/lib/openxml/package.rb
+++ b/lib/openxml/package.rb
@@ -115,7 +115,7 @@ module OpenXml
 
     def set_defaults
       presets = self.class.content_types_presets
-      @content_types = Parts::ContentTypes.new(presets.defaults, presets.overrides)
+      @content_types = Parts::ContentTypes.new(presets.defaults.dup, presets.overrides.dup)
       add_part "[Content_Types].xml", content_types
 
       @rels = Parts::Rels.new


### PR DESCRIPTION
The defaults and overrides for content types were global to a package.
That means that if we add more at runtime they end up added to all
packages created after that point. We want to only add them to an
instance of package.

The A Team