### PR TITLE
Allow relationships to be built outside of rels

### DIFF
--- a/lib/openxml/parts/rels.rb
+++ b/lib/openxml/parts/rels.rb
@@ -1,4 +1,5 @@
 require "securerandom"
+require "openxml/relationship"
 require "nokogiri"
 
 module OpenXml
@@ -23,9 +24,13 @@ module OpenXml
       end
 
       def add_relationship(type, target, id=nil, target_mode=nil)
-        Relationship.new(type, target, id, target_mode).tap do |relationship|
+        OpenXml::Elements::Relationship.new(type, target, id, target_mode).tap do |relationship|
           relationships.push relationship
         end
+      end
+
+      def push(relationship)
+        relationships.push relationship
       end
 
       def each(&block)
@@ -45,12 +50,6 @@ module OpenXml
               xml.Relationship(attributes)
             end
           end
-        end
-      end
-
-      class Relationship < Struct.new(:type, :target, :id, :target_mode)
-        def initialize(type, target, id=nil, target_mode=nil)
-          super type, target, id || "R#{SecureRandom.hex}", target_mode
         end
       end
 

--- a/lib/openxml/relationship.rb
+++ b/lib/openxml/relationship.rb
@@ -1,0 +1,9 @@
+module OpenXml
+  module Elements
+      class Relationship < Struct.new(:type, :target, :id, :target_mode)
+        def initialize(type, target, id=nil, target_mode=nil)
+          super type, target, id || "R#{SecureRandom.hex}", target_mode
+        end
+      end
+  end
+end


### PR DESCRIPTION
This is because in some cases it is nice to not build a new rels each
time you push a rel. This means that the rels can have the same ref ids
no matter what rel file they are in. This will also reduce memory
footprint and time.

Amos King @adkron <amos@binarynoggin.com>