### PR TITLE
Properties Attributes

### DIFF
--- a/lib/openxml/has_attributes.rb
+++ b/lib/openxml/has_attributes.rb
@@ -7,7 +7,7 @@ module OpenXml
 
     module ClassMethods
 
-      def attribute(name, expects: nil, one_of: nil, in_range: nil, displays_as: nil, namespace: nil, matches: nil, deprecated: false)
+      def attribute(name, expects: nil, one_of: nil, in_range: nil, displays_as: nil, namespace: nil, matches: nil, validation: nil, deprecated: false)
         bad_names = %w{ tag name namespace properties_tag }
         raise ArgumentError if bad_names.member? name.to_s
 
@@ -18,6 +18,7 @@ module OpenXml
           send(expects, value) unless expects.nil?
           matches?(value, matches) unless matches.nil?
           in_range?(value, in_range) unless in_range.nil?
+          validation.call(value) if validation.respond_to? :call
           instance_variable_set "@#{name}", value
         end
 

--- a/lib/openxml/has_children.rb
+++ b/lib/openxml/has_children.rb
@@ -26,5 +26,6 @@ module OpenXml
     def render?
       super || children.any?
     end
+
   end
 end

--- a/test/has_properties_test.rb
+++ b/test/has_properties_test.rb
@@ -52,11 +52,18 @@ class HasPropertiesTest < Minitest::Test
     context "#to_xml" do
       setup do
         base_class = Class.new do
-          attr_reader :namespace
+          def self.namespace
+            :w
+          end
+
+          def namespace
+            self.class.namespace
+          end
 
           def to_xml(xml)
-            yield xml if block_given?
-            xml
+            xml.public_send(tag, "xmlns:w" => "http://microsoft.com") do
+              yield xml if block_given?
+            end
           end
         end
 
@@ -64,8 +71,12 @@ class HasPropertiesTest < Minitest::Test
           include OpenXml::HasProperties
           value_property :value_property
 
-          def tag
+          def self.tag
             "p"
+          end
+
+          def tag
+            self.class.tag
           end
         end
       end
@@ -77,7 +88,7 @@ class HasPropertiesTest < Minitest::Test
         builder = Nokogiri::XML::Builder.new
         an_element.to_xml(builder)
 
-        assert %r{<pPr/>} =~ builder.to_xml
+        assert %r{<w:pPr/>} =~ builder.to_xml
       end
 
       should "call to_xml on each property" do

--- a/test/has_properties_test.rb
+++ b/test/has_properties_test.rb
@@ -106,6 +106,24 @@ class HasPropertiesTest < Minitest::Test
         end
       end
     end
+
+    should "allow attributes to be set on the properties tag" do
+      element = Class.new(OpenXml::Element) do
+        include OpenXml::HasProperties
+        tag :p
+        namespace :w
+
+        properties_attribute :bold, displays_as: :b, expects: :boolean
+      end.new
+      element.bold = true
+
+      builder = Nokogiri::XML::Builder.new
+      builder.document("xmlns:w" => "http://microsoft.com") do |xml|
+        element.to_xml(xml)
+      end
+
+      assert_match /w:pPr b="true"/, builder.to_xml
+    end
   end
 
 end


### PR DESCRIPTION
Curious what you think of the API. It seemed intuitive to me to have the methods available to get/set directly on the element with properties so that you can set these "properties attributes" as if they were normal properties, but then the actual handling of having attributes on the properties tag itself is handled by a normal `OpenXml::Element`.