### PR TITLE
Property classes

### DIFF
--- a/lib/openxml/properties.rb
+++ b/lib/openxml/properties.rb
@@ -1,0 +1,22 @@
+module OpenXml
+  module Properties
+  end
+end
+
+require "openxml/properties/base_property"
+require "openxml/properties/complex_property"
+require "openxml/properties/value_property"
+
+require "openxml/properties/boolean_property"
+require "openxml/properties/integer_property"
+require "openxml/properties/positive_integer_property"
+require "openxml/properties/string_property"
+require "openxml/properties/on_off_property"
+require "openxml/properties/toggle_property"
+
+require "openxml/properties/container_property"
+require "openxml/properties/transparent_container_property"
+
+Dir.glob(File.join(File.dirname(__FILE__), "properties", "*.rb").to_s).each do |file|
+  require file
+end

--- a/lib/openxml/properties/base_property.rb
+++ b/lib/openxml/properties/base_property.rb
@@ -1,0 +1,81 @@
+module OpenXml
+  module Properties
+    class BaseProperty
+      attr_reader :value
+
+      class << self
+        attr_reader :property_name
+        attr_reader :allowed_tags
+
+        def tag_is_one_of(tags)
+          attr_accessor :tag
+          @allowed_tags = tags
+        end
+
+        def tag(*args)
+          @tag = args.first if args.any?
+          @tag
+        end
+
+        def name(*args)
+          @property_name = args.first if args.any?
+          @name
+        end
+
+        def namespace(*args)
+          @namespace = args.first if args.any?
+          @namespace
+        end
+
+      end
+
+      def initialize(tag=nil, *_args)
+        return unless self.class.allowed_tags
+        validate_tag tag
+        @tag = tag
+      end
+
+      def validate_tag(tag)
+        return if self.class.allowed_tags.include?(tag)
+        allowed = self.class.allowed_tags.join(", ")
+        message = "Invalid tag name for #{name}: #{tag.inspect}. It should be one of #{allowed}."
+        raise ArgumentError, message
+      end
+
+      def render?
+        !value.nil?
+      end
+
+      def name
+        self.class.property_name || default_name
+      end
+
+      def default_name
+        class_name.gsub(/(.)([A-Z])/, '\1_\2').downcase
+      end
+
+      def tag
+        self.class.tag || default_tag
+      end
+
+      def default_tag
+        (class_name[0, 1].downcase + class_name[1..-1]).to_sym
+      end
+
+      def namespace
+        self.class.namespace
+      end
+
+    private
+
+      def apply_namespace(xml)
+        namespace.nil? ? xml : xml[namespace]
+      end
+
+      def class_name
+        self.class.to_s.split(/::/).last
+      end
+
+    end
+  end
+end

--- a/lib/openxml/properties/boolean_property.rb
+++ b/lib/openxml/properties/boolean_property.rb
@@ -1,0 +1,15 @@
+module OpenXml
+  module Properties
+    class BooleanProperty < ValueProperty
+
+      def ok_values
+        [nil, true, false]
+      end
+
+      def to_xml(xml)
+        super if value
+      end
+
+    end
+  end
+end

--- a/lib/openxml/properties/complex_property.rb
+++ b/lib/openxml/properties/complex_property.rb
@@ -1,0 +1,21 @@
+require "openxml/has_attributes"
+
+module OpenXml
+  module Properties
+    class ComplexProperty < BaseProperty
+      include HasAttributes
+
+      def to_xml(xml)
+        return unless render?
+        apply_namespace(xml).public_send(tag, xml_attributes) do
+          yield xml if block_given?
+        end
+      end
+
+      def render?
+        !xml_attributes.empty?
+      end
+
+    end
+  end
+end

--- a/lib/openxml/properties/container_property.rb
+++ b/lib/openxml/properties/container_property.rb
@@ -1,0 +1,69 @@
+require "openxml/has_attributes"
+
+module OpenXml
+  module Properties
+    class ContainerProperty < BaseProperty
+      include Enumerable
+      include HasAttributes
+
+      class << self
+
+        def child_class(*args)
+          unless args.empty?
+            @child_classes = args.map { |arg|
+              prop_name = arg.to_s.split(/_/).map(&:capitalize).join # LazyCamelCase
+              Properties.const_get prop_name
+            }
+          end
+
+          @child_classes
+        end
+        alias child_classes child_class
+
+      end
+
+      def initialize
+        @children = []
+      end
+
+      def <<(child)
+        raise ArgumentError, invalid_child_message unless valid_child?(child)
+        children << child
+      end
+
+      def each(*args, &block)
+        children.each(*args, &block)
+      end
+
+      def render?
+        !children.length.zero?
+      end
+
+      def to_xml(xml)
+        return unless render?
+
+        apply_namespace(xml).public_send(tag, xml_attributes) {
+          each { |child| child.to_xml(xml) }
+        }
+      end
+
+    private
+
+      attr_reader :children
+
+      def invalid_child_message
+        class_name = self.class.to_s.split(/::/).last
+        "#{class_name} must be instances of one of the following: #{child_classes}"
+      end
+
+      def valid_child?(child)
+        child_classes.any? { |child_class| child.is_a?(child_class) }
+      end
+
+      def child_classes
+        self.class.child_classes
+      end
+
+    end
+  end
+end

--- a/lib/openxml/properties/integer_property.rb
+++ b/lib/openxml/properties/integer_property.rb
@@ -1,0 +1,15 @@
+module OpenXml
+  module Properties
+    class IntegerProperty < ValueProperty
+
+      def valid?
+        value.is_a? Integer
+      end
+
+      def invalid_message
+        "Invalid #{name}: must be an integer"
+      end
+
+    end
+  end
+end

--- a/lib/openxml/properties/on_off_property.rb
+++ b/lib/openxml/properties/on_off_property.rb
@@ -1,0 +1,16 @@
+module OpenXml
+  module Properties
+    class OnOffProperty < ValueProperty
+
+      def ok_values
+        [true, false, :on, :off] # :on and :off are from the Transitional Spec
+      end
+
+      def to_xml(xml)
+        return apply_namespace(xml).public_send(tag) if value == true
+        super
+      end
+
+    end
+  end
+end

--- a/lib/openxml/properties/positive_integer_property.rb
+++ b/lib/openxml/properties/positive_integer_property.rb
@@ -1,0 +1,15 @@
+module OpenXml
+  module Properties
+    class PositiveIntegerProperty < IntegerProperty
+
+      def valid?
+        super && value >= 0
+      end
+
+      def invalid_message
+        "Invalid #{name}: must be a positive integer"
+      end
+
+    end
+  end
+end

--- a/lib/openxml/properties/string_property.rb
+++ b/lib/openxml/properties/string_property.rb
@@ -1,0 +1,15 @@
+module OpenXml
+  module Properties
+    class StringProperty < ValueProperty
+
+      def valid?
+        value.is_a?(String) && !value.length.zero?
+      end
+
+      def invalid_message
+        "Invalid value for #{name}; string expected (provided: #{value.inspect})"
+      end
+
+    end
+  end
+end

--- a/lib/openxml/properties/toggle_property.rb
+++ b/lib/openxml/properties/toggle_property.rb
@@ -1,0 +1,11 @@
+module OpenXml
+  module Properties
+    class ToggleProperty < OnOffProperty
+      # Toggle properties are no different in representation than on/off properties;
+      # rather, the difference is in how they compose with one another (cf.
+      # Section 17.7.3). It's helpful, then, to retain the concept, but entirely
+      # unnecessary to duplicate implementation.
+      # cf. Section A.6.9 of the spec, and Section A.7.9 of the transitional spec.
+    end
+  end
+end

--- a/lib/openxml/properties/transparent_container_property.rb
+++ b/lib/openxml/properties/transparent_container_property.rb
@@ -1,0 +1,12 @@
+module OpenXml
+  module Properties
+    class TransparentContainerProperty < ContainerProperty
+
+      def to_xml(xml)
+        return unless render?
+        each { |child| child.to_xml(xml) }
+      end
+
+    end
+  end
+end

--- a/lib/openxml/properties/value_property.rb
+++ b/lib/openxml/properties/value_property.rb
@@ -1,0 +1,35 @@
+module OpenXml
+  module Properties
+    class ValueProperty < BaseProperty
+      attr_reader :value
+
+      def initialize(value)
+        @value = value
+        raise ArgumentError, invalid_message unless valid?
+      end
+
+      def valid?
+        ok_values.member? value
+      end
+
+      def invalid_message
+        "#{value.inspect} is an invalid value for #{name}; acceptable: #{ok_values.join(", ")}"
+      end
+
+      def render?
+        !value.nil?
+      end
+
+      def to_xml(xml)
+        apply_namespace(xml).public_send tag, :"#{value_attribute}" => value
+      end
+
+    private
+
+      def value_attribute
+        namespace.nil? ? "val" : "#{namespace}:val"
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This mostly copies over the base properties classes from `OpenXml::Docx`. The major changes were related to the `to_xml` methods, removing the default `:w` namespace and allowing for entirely non-namespaced properties.