### PR TITLE
Render Properties as Direct Children

### DIFF
--- a/lib/openxml/has_properties.rb
+++ b/lib/openxml/has_properties.rb
@@ -12,6 +12,16 @@ module OpenXml
         @properties_tag
       end
 
+      def omit_properties_tag(*args)
+        @omit_properties_tag = args.first if args.any?
+        @omit_properties_tag
+      end
+      alias omit_properties_tag? omit_properties_tag
+
+      def properties_are_children
+        omit_properties_tag(true)
+      end
+
       def value_property(name, as: nil)
         attr_reader name
 
@@ -88,8 +98,12 @@ module OpenXml
       props = properties.keys.map(&method(:send)).compact
       return if props.none?(&:render?) && properties_attributes.none?
 
-      properties_element.to_xml(xml) do
+      if omit_properties_tag?
         props.each { |prop| prop.to_xml(xml) }
+      else
+        properties_element.to_xml(xml) do
+          props.each { |prop| prop.to_xml(xml) }
+        end
       end
     end
 
@@ -105,6 +119,10 @@ module OpenXml
 
     def default_properties_tag
       :"#{tag}Pr"
+    end
+
+    def omit_properties_tag?
+      self.class.omit_properties_tag?
     end
 
   end


### PR DESCRIPTION
This allows for `OpenXml::Elements` to behave as the properties tag when necessary. This allows for some edge cases that come up in PresentationML and DrawingML. First, the case where the properties tag differs in namespace from its container:
```xml
<p:txBody>
  <a:bodyPr/>
</p:txBody>
```

Secondly, the case where you want multiple properties tags within the same container:
```xml
<p:defaultTextStyle>
  <a:defPPr/>
  <a:lvl1pPr/>
</p:defaultTextStyle>
```