### PR TITLE
Mutually exclusive properties

### DIFF
--- a/lib/openxml/has_attributes.rb
+++ b/lib/openxml/has_attributes.rb
@@ -7,7 +7,7 @@ module OpenXml
 
     module ClassMethods
 
-      def attribute(name, expects: nil, one_of: nil, in_range: nil, displays_as: nil, namespace: nil, matches: nil, deprecated: false)
+      def attribute(name, expects: nil, one_of: nil, in_range: nil, displays_as: nil, namespace: nil, matches: nil, validation: nil, deprecated: false)
         bad_names = %w{ tag name namespace properties_tag }
         raise ArgumentError if bad_names.member? name.to_s
 
@@ -18,6 +18,7 @@ module OpenXml
           send(expects, value) unless expects.nil?
           matches?(value, matches) unless matches.nil?
           in_range?(value, in_range) unless in_range.nil?
+          validation.call(value) if validation.respond_to? :call
           instance_variable_set "@#{name}", value
         end
 

--- a/lib/openxml/has_children.rb
+++ b/lib/openxml/has_children.rb
@@ -26,5 +26,6 @@ module OpenXml
     def render?
       super || children.any?
     end
+
   end
 end

--- a/lib/openxml/has_properties.rb
+++ b/lib/openxml/has_properties.rb
@@ -65,6 +65,19 @@ module OpenXml
         end
       end
 
+      def mutually_exclusive(*property_names)
+        property_names.each do |property_name|
+          alias_method :"__set_#{property_name}", :"#{property_name}="
+          define_method "#{property_name}=" do |value|
+            message = "Only one of #{property_names.join(", ")} can be set at a time"
+            other_properties = (property_names - [ property_name ])
+            values_nil = other_properties.map { |name| public_send(name).nil? } + [ value.nil? ]
+            raise ArgumentError, message unless values_nil.one?(&:!)
+            public_send(:"__set_#{property_name}", value)
+          end
+        end
+      end
+
       def properties_element
         this = self
         @properties_element ||= Class.new(OpenXml::Element) do

--- a/lib/openxml/has_properties.rb
+++ b/lib/openxml/has_properties.rb
@@ -12,6 +12,16 @@ module OpenXml
         @properties_tag
       end
 
+      def omit_properties_tag(*args)
+        @omit_properties_tag = args.first if args.any?
+        @omit_properties_tag
+      end
+      alias omit_properties_tag? omit_properties_tag
+
+      def properties_are_children
+        omit_properties_tag(true)
+      end
+
       def value_property(name, as: nil)
         attr_reader name
 
@@ -88,8 +98,12 @@ module OpenXml
       props = properties.keys.map(&method(:send)).compact
       return if props.none?(&:render?) && properties_attributes.none?
 
-      properties_element.to_xml(xml) do
+      if omit_properties_tag?
         props.each { |prop| prop.to_xml(xml) }
+      else
+        properties_element.to_xml(xml) do
+          props.each { |prop| prop.to_xml(xml) }
+        end
       end
     end
 
@@ -105,6 +119,10 @@ module OpenXml
 
     def default_properties_tag
       :"#{tag}Pr"
+    end
+
+    def omit_properties_tag?
+      self.class.omit_properties_tag?
     end
 
   end

--- a/test/has_properties_test.rb
+++ b/test/has_properties_test.rb
@@ -52,11 +52,18 @@ class HasPropertiesTest < Minitest::Test
     context "#to_xml" do
       setup do
         base_class = Class.new do
-          attr_reader :namespace
+          def self.namespace
+            :w
+          end
+
+          def namespace
+            self.class.namespace
+          end
 
           def to_xml(xml)
-            yield xml if block_given?
-            xml
+            xml.public_send(tag, "xmlns:w" => "http://microsoft.com") do
+              yield xml if block_given?
+            end
           end
         end
 
@@ -64,8 +71,12 @@ class HasPropertiesTest < Minitest::Test
           include OpenXml::HasProperties
           value_property :value_property
 
-          def tag
+          def self.tag
             "p"
+          end
+
+          def tag
+            self.class.tag
           end
         end
       end
@@ -77,7 +88,7 @@ class HasPropertiesTest < Minitest::Test
         builder = Nokogiri::XML::Builder.new
         an_element.to_xml(builder)
 
-        assert %r{<pPr/>} =~ builder.to_xml
+        assert %r{<w:pPr/>} =~ builder.to_xml
       end
 
       should "call to_xml on each property" do

--- a/test/has_properties_test.rb
+++ b/test/has_properties_test.rb
@@ -106,6 +106,24 @@ class HasPropertiesTest < Minitest::Test
         end
       end
     end
+
+    should "allow attributes to be set on the properties tag" do
+      element = Class.new(OpenXml::Element) do
+        include OpenXml::HasProperties
+        tag :p
+        namespace :w
+
+        properties_attribute :bold, displays_as: :b, expects: :boolean
+      end.new
+      element.bold = true
+
+      builder = Nokogiri::XML::Builder.new
+      builder.document("xmlns:w" => "http://microsoft.com") do |xml|
+        element.to_xml(xml)
+      end
+
+      assert_match /w:pPr b="true"/, builder.to_xml
+    end
   end
 
 end


### PR DESCRIPTION
Based on #21. Relevant commit c20ad69

I'm open to suggestions on what to name the method. I ended up settling on `mutually_exclusive`, but I don't love it; it gets the exclusivity across, but not that we're dealing with properties. Conversely, though, any method names I tried that included "properties" ended up seeming too verbose... So `mutually_exclusive` it was. 🤷‍♂️ 