### PR TITLE
Added ContainsProperties Module

### DIFF
--- a/lib/openxml/contains_properties.rb
+++ b/lib/openxml/contains_properties.rb
@@ -1,0 +1,25 @@
+require "openxml/has_properties"
+
+module OpenXml
+  module ContainsProperties
+
+    def self.included(base)
+      base.class_eval do
+        include HasProperties
+        include InstanceMethods
+      end
+    end
+
+    module InstanceMethods
+
+      def property_xml(xml)
+        props = properties.keys.map(&method(:send)).compact
+        return if props.none?(&:render?) && properties_attributes.none?
+
+        props.each { |prop| prop.to_xml(xml) }
+      end
+
+    end
+
+  end
+end

--- a/lib/openxml/contains_properties.rb
+++ b/lib/openxml/contains_properties.rb
@@ -13,9 +13,8 @@ module OpenXml
     module InstanceMethods
 
       def property_xml(xml)
-        props = properties.keys.map(&method(:send)).compact
-        return if props.none?(&:render?) && properties_attributes.none?
-
+        props = active_properties
+        return unless render_properties? props
         props.each { |prop| prop.to_xml(xml) }
       end
 

--- a/lib/openxml/has_properties.rb
+++ b/lib/openxml/has_properties.rb
@@ -77,6 +77,11 @@ module OpenXml
       properties_element.attributes
     end
 
+    def render?
+      return true unless defined?(super)
+      render_properties? || super
+    end
+
     def to_xml(xml)
       super(xml) do
         property_xml(xml)
@@ -85,8 +90,8 @@ module OpenXml
     end
 
     def property_xml(xml)
-      props = properties.keys.map(&method(:send)).compact
-      return if props.none?(&:render?) && properties_attributes.none?
+      props = active_properties
+      return unless render_properties? props
 
       properties_element.to_xml(xml) do
         props.each { |prop| prop.to_xml(xml) }
@@ -97,6 +102,14 @@ module OpenXml
 
     def properties
       self.class.properties
+    end
+
+    def active_properties
+      properties.keys.map { |property| instance_variable_get("@#{property}") }.compact
+    end
+
+    def render_properties?(properties=active_properties)
+      properties.any?(&:render?) || properties_attributes.any?
     end
 
     def properties_tag

--- a/lib/openxml/properties/on_off_property.rb
+++ b/lib/openxml/properties/on_off_property.rb
@@ -7,8 +7,13 @@ module OpenXml
       end
 
       def to_xml(xml)
-        return apply_namespace(xml).public_send(tag) if value == true
-        super
+        if value == true
+          apply_namespace(xml).public_send(tag) do
+            yield xml if block_given?
+          end
+        else
+          super
+        end
       end
 
     end

--- a/lib/openxml/properties/value_property.rb
+++ b/lib/openxml/properties/value_property.rb
@@ -21,7 +21,9 @@ module OpenXml
       end
 
       def to_xml(xml)
-        apply_namespace(xml).public_send tag, :"#{value_attribute}" => value
+        apply_namespace(xml).public_send(tag, :"#{value_attribute}" => value) do
+          yield xml if block_given?
+        end
       end
 
     private

--- a/test/contains_properties_test.rb
+++ b/test/contains_properties_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+require "openxml/element"
+require "openxml/properties"
+require "openxml/contains_properties"
+
+class ContainsPropertiesTest < Minitest::Test
+  should "allow properties to be rendered as direct children" do
+    element = Class.new(OpenXml::Element) do
+      include OpenXml::ContainsProperties
+      tag :bodyPr
+      namespace :a
+
+      value_property :string_property
+    end.new
+    element.string_property = "A Value"
+
+    rendered_xml = build(element)
+    refute_match /a:bodyPrPr/, rendered_xml
+    assert_match /a:stringProperty val="A Value"/, rendered_xml
+  end
+
+private
+
+  def build(element)
+    builder = Nokogiri::XML::Builder.new
+    builder.document("xmlns:a" => "http://microsoft.com") do |xml|
+      element.to_xml(xml)
+    end
+    builder.to_xml
+  end
+
+end

--- a/test/has_properties_test.rb
+++ b/test/has_properties_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "openxml/element"
+require "openxml/properties"
 require "openxml/has_properties"
 
 class HasPropertiesTest < Minitest::Test
@@ -11,20 +12,20 @@ class HasPropertiesTest < Minitest::Test
         @element = Class.new do
           include OpenXml::HasProperties
 
-          value_property :value_property
+          value_property :string_property
         end
       end
 
       should "generate accessor methods for the property" do
         an_element = element.new
-        assert an_element.respond_to? :value_property
-        assert an_element.respond_to? :value_property=
+        assert an_element.respond_to? :string_property
+        assert an_element.respond_to? :string_property=
       end
 
       should "instantiate the property on assignment of a value" do
         an_element = element.new
-        an_element.value_property = "A Value"
-        an_element.value_property.is_a?(OpenXml::Properties::ValueProperty)
+        an_element.string_property = "A Value"
+        an_element.string_property.is_a?(OpenXml::Properties::StringProperty)
       end
     end
 
@@ -33,19 +34,19 @@ class HasPropertiesTest < Minitest::Test
         @element = Class.new do
           include OpenXml::HasProperties
 
-          property :some_property
+          property :complex_property
         end
       end
 
       should "generate a reader method only for the property" do
         an_element = element.new
-        assert an_element.respond_to? :some_property
+        assert an_element.respond_to? :complex_property
       end
 
       should "instantiate the property on first access" do
         an_element = element.new
-        refute an_element.instance_variable_get("@some_property")
-        assert an_element.some_property.is_a?(OpenXml::Properties::SomeProperty)
+        refute an_element.instance_variable_get("@complex_property")
+        assert an_element.complex_property.is_a?(OpenXml::Properties::ComplexProperty)
       end
     end
 
@@ -69,7 +70,7 @@ class HasPropertiesTest < Minitest::Test
 
         @element = Class.new(base_class) do
           include OpenXml::HasProperties
-          value_property :value_property
+          value_property :boolean_property
 
           def self.tag
             "p"
@@ -83,12 +84,12 @@ class HasPropertiesTest < Minitest::Test
 
       should "generate the property tag as part of to_xml" do
         an_element = element.new
-        an_element.value_property = true
+        an_element.boolean_property = true
 
         builder = Nokogiri::XML::Builder.new
         an_element.to_xml(builder)
 
-        assert %r{<w:pPr/>} =~ builder.to_xml
+        assert_match /<w:pPr>/, builder.to_xml
       end
 
       should "call to_xml on each property" do
@@ -97,9 +98,9 @@ class HasPropertiesTest < Minitest::Test
         def mock.render?; true; end
         mock.expect(:to_xml, nil, [ builder ])
 
-        OpenXml::Properties::ValueProperty.stub :new, mock do
+        OpenXml::Properties::BooleanProperty.stub :new, mock do
           an_element = element.new
-          an_element.value_property = true
+          an_element.boolean_property = true
 
           an_element.to_xml(builder)
           mock.verify
@@ -126,34 +127,4 @@ class HasPropertiesTest < Minitest::Test
     end
   end
 
-end
-
-
-
-module OpenXml
-  module Properties
-
-    class SomeProperty
-
-      def to_xml(builder)
-        yield builder if block_given?
-        builder
-      end
-
-    end
-
-    class ValueProperty < SomeProperty
-
-      def initialize(value)
-        raise ArgumentError unless value
-        @value = value
-      end
-
-      def render?
-        !!@value
-      end
-
-    end
-
-  end
 end


### PR DESCRIPTION
Replaces #21 

From that PR's description:

This allows for `OpenXml::Elements` to behave as the properties tag when necessary. This allows for some edge cases that come up in PresentationML and DrawingML. First, the case where the properties tag differs in namespace from its container:
```xml
<p:txBody>
  <a:bodyPr/>
</p:txBody>
```

Secondly, the case where you want multiple properties tags within the same container:
```xml
<p:defaultTextStyle>
  <a:defPPr/>
  <a:lvl1pPr/>
</p:defaultTextStyle>
```