### PR TITLE
Property Choice

### DIFF
--- a/lib/openxml/has_properties.rb
+++ b/lib/openxml/has_properties.rb
@@ -30,9 +30,9 @@ module OpenXml
         class_name = properties[name].split("_").map(&:capitalize).join
 
         class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{name}
+        def #{name}(*args)
           if instance_variable_get("@#{name}").nil?
-            instance_variable_set "@#{name}", Properties::#{class_name}.new
+            instance_variable_set "@#{name}", Properties::#{class_name}.new(*args)
           end
 
           instance_variable_get "@#{name}"

--- a/lib/openxml/has_properties.rb
+++ b/lib/openxml/has_properties.rb
@@ -1,6 +1,8 @@
 module OpenXml
   module HasProperties
 
+    class ChoiceGroupUniqueError < RuntimeError; end
+
     def self.included(base)
       base.extend ClassMethods
     end
@@ -18,8 +20,12 @@ module OpenXml
         properties[name] = (as || name).to_s
         class_name = properties[name].split("_").map(&:capitalize).join
 
+        (choice_groups[@current_group] ||= []).push(name) unless @current_group.nil?
+
         class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}=(value)
+          group_index = #{@current_group}
+          ensure_unique_in_group(:#{name}, group_index) unless group_index.nil?
           instance_variable_set "@#{name}", Properties::#{class_name}.new(value)
         end
         CODE
@@ -29,9 +35,13 @@ module OpenXml
         properties[name] = (as || name).to_s
         class_name = properties[name].split("_").map(&:capitalize).join
 
+        (choice_groups[@current_group] ||= []).push(name) unless @current_group.nil?
+
         class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}(*args)
           if instance_variable_get("@#{name}").nil?
+            group_index = #{@current_group}
+            ensure_unique_in_group(:#{name}, group_index) unless group_index.nil?
             instance_variable_set "@#{name}", Properties::#{class_name}.new(*args)
           end
 
@@ -40,8 +50,18 @@ module OpenXml
         CODE
       end
 
+      def property_choice
+        @current_group = choice_groups.length
+        yield
+        @current_group = nil
+      end
+
       def properties
         @properties ||= {}
+      end
+
+      def choice_groups
+        @choice_groups ||= []
       end
 
       def properties_attribute(name, **args)
@@ -118,6 +138,17 @@ module OpenXml
 
     def default_properties_tag
       :"#{tag}Pr"
+    end
+
+    def choice_groups
+      self.class.choice_groups
+    end
+
+    def ensure_unique_in_group(name, group_index)
+      other_names = (choice_groups[group_index] - [name])
+      unique = other_names.all? { |other_name| instance_variable_get("@#{other_name}").nil? }
+      message = "Property #{name} cannot also be set with #{other_names.join(", ")}."
+      raise ChoiceGroupUniqueError, message unless unique
     end
 
   end

--- a/test/has_properties_test.rb
+++ b/test/has_properties_test.rb
@@ -35,6 +35,7 @@ class HasPropertiesTest < Minitest::Test
           include OpenXml::HasProperties
 
           property :complex_property
+          property :polymorphic_property
         end
       end
 
@@ -47,6 +48,12 @@ class HasPropertiesTest < Minitest::Test
         an_element = element.new
         refute an_element.instance_variable_get("@complex_property")
         assert an_element.complex_property.is_a?(OpenXml::Properties::ComplexProperty)
+      end
+
+      should "allow a parameter to be passed in to initialize on access" do
+        an_element = element.new
+        an_element.polymorphic_property(:tagTwo)
+        assert_equal an_element.polymorphic_property.tag, :tagTwo
       end
     end
 
@@ -127,4 +134,14 @@ class HasPropertiesTest < Minitest::Test
     end
   end
 
+end
+
+module OpenXml
+  module Properties
+
+    class PolymorphicProperty < BaseProperty
+      tag_is_one_of %i{ tagOne tagTwo }
+    end
+
+  end
 end

--- a/test/has_properties_test.rb
+++ b/test/has_properties_test.rb
@@ -57,6 +57,33 @@ class HasPropertiesTest < Minitest::Test
       end
     end
 
+    context ".property_choice" do
+      setup do
+        @element = Class.new do
+          include OpenXml::HasProperties
+
+          property_choice do
+            value_property :property_one, as: :boolean_property
+            property :property_two, as: :complex_property
+          end
+        end
+      end
+
+      should "raise an exception when attempting to use more than one property in the group" do
+        an_element = element.new
+        assert_raises OpenXml::HasProperties::ChoiceGroupUniqueError do
+          an_element.property_one = true
+          an_element.property_two
+        end
+
+        another_element = element.new
+        assert_raises OpenXml::HasProperties::ChoiceGroupUniqueError do
+          another_element.property_two
+          another_element.property_one = true
+        end
+      end
+    end
+
     context "#to_xml" do
       setup do
         base_class = Class.new do


### PR DESCRIPTION
This would allow properties to be grouped as mutually-exclusive choices. It allows us to enforce with exceptions `<xsd:choice/>` designations in the OpenXml spec.

For example, when designating a color in DrawingML, one has a choice of: `<scrgbClr/>`, `<srgbClr/>`, `<hslClr/>`, `<sysClr/>`, `<schemeClr/>`, and `<prstClr/>`. Each of these are properly separate properties with their own attributes (and in some cases properties of their own!), but only _one_ may be used as a child of some element looking for a color.

---

I'm not 100% on the first commit. The mechanism for assigning a tag in this way is already there, but the second commit, I _think_, mostly obviates the need for this kind of polymorphism, since we can either create a choice group and/or use inheritance to change tags as necessary. But since the underlying mechanism is there (from `BaseProperty`'s docx days), it also seems good to just take it the rest of the way so that kind of dynamic tag assignment can happen with `property` as well as `value_property`. ¯\\\_(ツ)_/¯

(As an aside, being able to dynamically assign tags to complex properties by marking them as a `value_property` in the containing class is super weird and seems like an abuse of the API, but ... it also works!)