### PR TITLE
Correctly Scoped Container Property Child Classes

### DIFF
--- a/lib/openxml/properties/container_property.rb
+++ b/lib/openxml/properties/container_property.rb
@@ -12,7 +12,8 @@ module OpenXml
           unless args.empty?
             @child_classes = args.map { |arg|
               prop_name = arg.to_s.split(/_/).map(&:capitalize).join # LazyCamelCase
-              Properties.const_get prop_name
+              const_name = (self.to_s.split(/::/)[0...-1] + [prop_name]).join("::")
+              Object.const_get const_name
             }
           end
 


### PR DESCRIPTION
Just `Properties` before was searching the `OpenXml::Properties` module for the generated class name, even when operating from a sublcass in a different scope.