### PR TITLE
Inheritable attributes

### DIFF
--- a/lib/openxml/has_attributes.rb
+++ b/lib/openxml/has_attributes.rb
@@ -27,7 +27,15 @@ module OpenXml
       end
 
       def attributes
-        @attributes ||= {}
+        @attributes ||= begin
+          if superclass.respond_to?(:attributes)
+            Hash[superclass.attributes.map { |name, attribute|
+              [ name, attribute.dup ]
+            }]
+          else
+            {}
+          end
+        end
       end
 
       def with_namespace(namespace, &block)

--- a/lib/openxml/has_properties.rb
+++ b/lib/openxml/has_properties.rb
@@ -25,7 +25,7 @@ module OpenXml
 
         class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}=(value)
-          group_index = #{@current_group}
+          group_index = #{@current_group.inspect}
           ensure_unique_in_group(:#{name}, group_index) unless group_index.nil?
           instance_variable_set "@#{name}", #{class_name}.new(value)
         end
@@ -42,7 +42,7 @@ module OpenXml
         class_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{name}(*args)
           if instance_variable_get("@#{name}").nil?
-            group_index = #{@current_group}
+            group_index = #{@current_group.inspect}
             ensure_unique_in_group(:#{name}, group_index) unless group_index.nil?
             instance_variable_set "@#{name}", #{class_name}.new(*args)
           end
@@ -59,11 +59,23 @@ module OpenXml
       end
 
       def properties
-        @properties ||= {}
+        @properties ||= begin
+          if superclass.respond_to?(:properties)
+            Hash[superclass.properties.map { |key, klass_name| [ key, klass_name.dup ] }]
+          else
+            {}
+          end
+        end
       end
 
       def choice_groups
-        @choice_groups ||= []
+        @choice_groups ||= begin
+          if superclass.respond_to?(:choice_groups)
+            superclass.choice_groups.map(&:dup)
+          else
+            []
+          end
+        end
       end
 
       def properties_attribute(name, **args)
@@ -79,7 +91,8 @@ module OpenXml
 
       def properties_element
         this = self
-        @properties_element ||= Class.new(OpenXml::Element) do
+        parent_klass = superclass.respond_to?(:properties_element) ? superclass.properties_element : OpenXml::Element
+        @properties_element ||= Class.new(parent_klass) do
           tag :"#{this.properties_tag || this.default_properties_tag}"
           namespace :"#{this.namespace}"
         end

--- a/lib/openxml/has_properties.rb
+++ b/lib/openxml/has_properties.rb
@@ -18,8 +18,9 @@ module OpenXml
         attr_reader name
 
         properties[name] = (as || name).to_s
+        classified_name = properties[name].split("_").map(&:capitalize).join
         class_name = klass.name unless klass.nil?
-        class_name ||= "Properties::#{properties[name].split("_").map(&:capitalize).join}"
+        class_name ||= (to_s.split("::")[0...-2] + ["Properties", classified_name]).join("::")
 
         (choice_groups[@current_group] ||= []).push(name) unless @current_group.nil?
 
@@ -34,8 +35,9 @@ module OpenXml
 
       def property(name, as: nil, klass: nil)
         properties[name] = (as || name).to_s
+        classified_name = properties[name].split("_").map(&:capitalize).join
         class_name = klass.name unless klass.nil?
-        class_name ||= "Properties::#{properties[name].split("_").map(&:capitalize).join}"
+        class_name ||= (to_s.split("::")[0...-2] + ["Properties", classified_name]).join("::")
 
         (choice_groups[@current_group] ||= []).push(name) unless @current_group.nil?
 

--- a/test/has_attributes_test.rb
+++ b/test/has_attributes_test.rb
@@ -72,6 +72,30 @@ class HasAttributesTest < Minitest::Test
     end
   end
 
+  context "a subclass of a class with attributes" do
+    should "inherit its superclass' attributes" do
+      element = Class.new(class_with_attribute(:an_attribute)).new
+      assert_equal %i{ an_attribute }, element.attributes.keys
+    end
+
+    should "not modify the attributes of its superclass" do
+      parent = class_with_attribute(:an_attribute)
+      element = Class.new(parent) do
+        attribute :another_attribute
+      end
+
+      assert_equal %i{ an_attribute another_attribute }, element.new.attributes.keys
+      assert_equal %i{ an_attribute }, parent.new.attributes.keys
+    end
+
+    should "inherit the accessors of its superclass" do
+      element = Class.new(class_with_attribute(:an_attribute)).new
+
+      assert element.respond_to? :an_attribute, "Should respond to read accessor"
+      assert element.respond_to? :an_attribute=, "Should respond to write accessor"
+    end
+  end
+
 private
 
   def class_with_attribute(attr_name, **args)

--- a/test/has_properties_test.rb
+++ b/test/has_properties_test.rb
@@ -120,10 +120,7 @@ class HasPropertiesTest < Minitest::Test
         an_element = element.new
         an_element.boolean_property = true
 
-        builder = Nokogiri::XML::Builder.new
-        an_element.to_xml(builder)
-
-        assert_match /<w:pPr>/, builder.to_xml
+        assert_match /<w:pPr>/, xml(an_element)
       end
 
       should "call to_xml on each property" do
@@ -152,13 +149,17 @@ class HasPropertiesTest < Minitest::Test
       end.new
       element.bold = true
 
-      builder = Nokogiri::XML::Builder.new
-      builder.document("xmlns:w" => "http://microsoft.com") do |xml|
-        element.to_xml(xml)
+      assert_match /w:pPr b="true"/, xml(element)
       end
 
-      assert_match /w:pPr b="true"/, builder.to_xml
+private
+
+  def xml(element)
+    builder = Nokogiri::XML::Builder.new
+    builder.document("xmlns:w" => "http://microsoft.com") do |xml|
+      element.to_xml(xml)
     end
+    builder.to_xml
   end
 
 end

--- a/test/has_properties_test.rb
+++ b/test/has_properties_test.rb
@@ -150,7 +150,104 @@ class HasPropertiesTest < Minitest::Test
       element.bold = true
 
       assert_match /w:pPr b="true"/, xml(element)
+    end
+  end
+
+  context "a subclass of a class that has included HasProperties" do
+    should "inherit the properties of its superclass" do
+      parent = Class.new do
+        include OpenXml::HasProperties
+        value_property :boolean_property
       end
+      child = Class.new(parent)
+
+      assert_equal %i{ boolean_property }, child.new.send(:properties).keys
+    end
+
+    should "not modify the properties of its superclass" do
+      parent = Class.new do
+        include OpenXml::HasProperties
+        value_property :boolean_property
+      end
+      child = Class.new(parent) do
+        value_property :another_bool, as: :boolean_property
+      end
+
+      assert_equal %i{ boolean_property }, parent.properties.keys
+      assert_equal %i{ another_bool boolean_property }, child.new.send(:properties).keys.sort
+    end
+
+    should "inherit the accessors of its superclass" do
+      parent = Class.new do
+        include OpenXml::HasProperties
+        value_property :boolean_property
+      end
+      child = Class.new(parent).new
+
+      assert child.respond_to?(:boolean_property=), "Should respond to property assignment"
+      assert child.respond_to?(:boolean_property), "Should respond to property accessor"
+    end
+
+    should "inherit the choice groups of its superclass" do
+      parent = Class.new do
+        include OpenXml::HasProperties
+        property_choice do
+          value_property :boolean_property
+        end
+      end
+      child = Class.new(parent).new
+
+      assert_equal 1, child.send(:choice_groups).count
+      assert_equal %i{ boolean_property }, child.send(:choice_groups).first
+    end
+
+    should "not modify the choice groups of its superclass" do
+      parent = Class.new do
+        include OpenXml::HasProperties
+        property_choice do
+          value_property :boolean_property
+        end
+      end
+      child = Class.new(parent) do
+        property_choice do
+          value_property :another_boolean, as: :boolean_property
+        end
+      end
+
+      assert_equal 1, parent.choice_groups.count
+      assert_equal %i{ boolean_property }, parent.choice_groups.first
+      assert_equal 2, child.choice_groups.count
+      assert_equal %i{ boolean_property }, child.choice_groups.first
+      assert_equal %i{ another_boolean }, child.choice_groups.last
+    end
+
+    should "inherit the attributes of the properties tag of its superclass" do
+      parent = Class.new(OpenXml::Element) do
+        include OpenXml::HasProperties
+        properties_attribute :an_attribute
+      end
+      child = Class.new(parent) do
+        tag :p
+      end
+
+      assert_equal %i{ an_attribute }, child.new.properties_attributes.keys
+    end
+
+    should "not modify the attributes of the properties tag of its superclass" do
+      parent = Class.new(OpenXml::Element) do
+        include OpenXml::HasProperties
+        tag :q
+        properties_attribute :an_attribute
+      end
+      child = Class.new(parent) do
+        tag :p
+        properties_attribute :another_attribute
+      end
+
+      assert_equal %i{ an_attribute }, parent.new.properties_attributes.keys
+      assert_equal %i{ an_attribute another_attribute }, child.new.properties_attributes.keys.sort
+    end
+  end
 
 private
 


### PR DESCRIPTION
I thought about trying to make other important class-level instance variables inheritable also, e.g., `tag` and `namespace`; however, I opted to omit those, as it's probably better for documentation purposes to have to specify those even on a subclass...