### PR TITLE
Required placeholders

### DIFF
--- a/lib/openxml/has_attributes.rb
+++ b/lib/openxml/has_attributes.rb
@@ -7,7 +7,8 @@ module OpenXml
 
     module ClassMethods
 
-      def attribute(name, expects: nil, one_of: nil, in_range: nil, displays_as: nil, namespace: nil, matches: nil, validation: nil, deprecated: false)
+      def attribute(name, expects: nil, one_of: nil, in_range: nil, displays_as: nil, namespace: nil, matches: nil, validation: nil, required: false, deprecated: false)
+        warn "[WARNING] `required` parameter is not yet implemented" if required
         bad_names = %w{ tag name namespace properties_tag }
         raise ArgumentError if bad_names.member? name.to_s
 

--- a/lib/openxml/has_properties.rb
+++ b/lib/openxml/has_properties.rb
@@ -14,7 +14,8 @@ module OpenXml
         @properties_tag ||= nil
       end
 
-      def value_property(name, as: nil, klass: nil)
+      def value_property(name, as: nil, klass: nil, required: false)
+        warn "[WARNING] `required` paramater is not yet implemented" if required
         attr_reader name
 
         properties[name] = (as || name).to_s
@@ -33,7 +34,8 @@ module OpenXml
         CODE
       end
 
-      def property(name, as: nil, klass: nil)
+      def property(name, as: nil, klass: nil, required: false)
+        warn "[WARNING] `required` parameter is not yet implemented" if required
         properties[name] = (as || name).to_s
         classified_name = properties[name].split("_").map(&:capitalize).join
         class_name = klass.name unless klass.nil?

--- a/lib/openxml/has_properties.rb
+++ b/lib/openxml/has_properties.rb
@@ -56,7 +56,8 @@ module OpenXml
         CODE
       end
 
-      def property_choice
+      def property_choice(required: false)
+        warn "[WARNING] `required` parameter is not yet implemented" if required
         @current_group = choice_groups.length
         yield
         @current_group = nil


### PR DESCRIPTION
Adds `required:` parameters to properties, attributes, and property choices. As of yet, these are unimplemented and so will warn the consuming package as such (but not raise an exception).