### PR TITLE
Added method to build out required properties

### DIFF
--- a/lib/openxml/contains_properties.rb
+++ b/lib/openxml/contains_properties.rb
@@ -18,6 +18,10 @@ module OpenXml
         props.each { |prop| prop.to_xml(xml) }
       end
 
+      def properties_attributes
+        {}
+      end
+
     end
 
   end

--- a/lib/openxml/has_attributes.rb
+++ b/lib/openxml/has_attributes.rb
@@ -115,6 +115,11 @@ module OpenXml
       raise ArgumentError, message if !value.is_a?(String) || value.length.zero?
     end
 
+    def string_or_blank(value)
+      message = "Invalid #{name}: must be a string, even if the string is empty"
+      raise ArgumentError, message unless value.is_a?(String)
+    end
+
     def in_range?(value, range)
       message = "Invalid #{name}: must be a number between #{range.begin} and #{range.end}"
       raise ArgumentError, message unless range.include?(value.to_i)

--- a/lib/openxml/has_attributes.rb
+++ b/lib/openxml/has_attributes.rb
@@ -8,7 +8,7 @@ module OpenXml
     module ClassMethods
 
       def attribute(name, expects: nil, one_of: nil, in_range: nil, displays_as: nil, namespace: nil, matches: nil, validation: nil, required: false, deprecated: false)
-        warn "[WARNING] `required` parameter is not yet implemented" if required
+        warn "[WARNING] `required` parameter is not yet implemented for attributes" if required
         bad_names = %w{ tag name namespace properties_tag }
         raise ArgumentError if bad_names.member? name.to_s
 

--- a/lib/openxml/has_properties.rb
+++ b/lib/openxml/has_properties.rb
@@ -14,11 +14,11 @@ module OpenXml
         @properties_tag ||= nil
       end
 
-      def value_property(name, as: nil, klass: nil, required: false)
+      def value_property(name, as: nil, klass: nil, required: false, default_value: nil)
         attr_reader name
 
         properties[name] = (as || name).to_s
-        required_properties.push name if required
+        required_properties[name] = default_value if required
         classified_name = properties[name].split("_").map(&:capitalize).join
         class_name = klass.to_s unless klass.nil?
         class_name ||= (to_s.split("::")[0...-2] + ["Properties", classified_name]).join("::")
@@ -36,7 +36,7 @@ module OpenXml
 
       def property(name, as: nil, klass: nil, required: false)
         properties[name] = (as || name).to_s
-        required_properties.push name if required
+        required_properties[name] = true if required
         classified_name = properties[name].split("_").map(&:capitalize).join
         class_name = klass.to_s unless klass.nil?
         class_name ||= (to_s.split("::")[0...-2] + ["Properties", classified_name]).join("::")
@@ -92,7 +92,7 @@ module OpenXml
           if superclass.respond_to?(:required_properties)
             superclass.required_properties.dup
           else
-            []
+            {}
           end
         end
       end
@@ -158,14 +158,10 @@ module OpenXml
     end
 
     def build_required_properties
-      required_properties.each do |prop|
-        public_send(:"#{prop}=", default_property_value_for(prop)) if respond_to? :"#{prop}="
+      required_properties.each do |prop, default_value|
+        public_send(:"#{prop}=", default_value) if respond_to? :"#{prop}="
         public_send(:"#{prop}")
       end
-    end
-
-    def default_property_value_for(_prop)
-      raise NotImplementedError
     end
 
   private

--- a/lib/openxml/has_properties.rb
+++ b/lib/openxml/has_properties.rb
@@ -123,6 +123,11 @@ module OpenXml
 
     end
 
+    def initialize(*_args)
+      super
+      build_required_properties
+    end
+
     def properties_element
       @properties_element ||= self.class.properties_element.new
     end
@@ -155,8 +160,7 @@ module OpenXml
     def build_required_properties
       required_properties.each do |prop|
         public_send(:"#{prop}=", default_property_value_for(prop)) if respond_to? :"#{prop}="
-        property_instance = public_send(:"#{prop}")
-        property_instance.build_required_properties if property_instance.respond_to?(:build_required_properties)
+        public_send(:"#{prop}")
       end
     end
 

--- a/lib/openxml/has_properties.rb
+++ b/lib/openxml/has_properties.rb
@@ -20,7 +20,7 @@ module OpenXml
         properties[name] = (as || name).to_s
         required_properties.push name if required
         classified_name = properties[name].split("_").map(&:capitalize).join
-        class_name = klass.name unless klass.nil?
+        class_name = klass.to_s unless klass.nil?
         class_name ||= (to_s.split("::")[0...-2] + ["Properties", classified_name]).join("::")
 
         (choice_groups[current_group] ||= []).push(name) unless current_group.nil?
@@ -38,7 +38,7 @@ module OpenXml
         properties[name] = (as || name).to_s
         required_properties.push name if required
         classified_name = properties[name].split("_").map(&:capitalize).join
-        class_name = klass.name unless klass.nil?
+        class_name = klass.to_s unless klass.nil?
         class_name ||= (to_s.split("::")[0...-2] + ["Properties", classified_name]).join("::")
 
         (choice_groups[current_group] ||= []).push(name) unless current_group.nil?

--- a/lib/openxml/render_when_empty.rb
+++ b/lib/openxml/render_when_empty.rb
@@ -1,0 +1,9 @@
+module OpenXml
+  module RenderWhenEmpty
+
+    def render?
+      true
+    end
+
+  end
+end

--- a/test/has_properties_test.rb
+++ b/test/has_properties_test.rb
@@ -184,7 +184,7 @@ class HasPropertiesTest < Minitest::Test
       end
       child = Class.new(parent)
 
-      assert_equal %i{ complex_property }, child.new.send(:required_properties)
+      assert_equal %i{ complex_property }, child.new.send(:required_properties).keys
     end
 
     should "not modify the required properties of its superclass" do
@@ -196,8 +196,8 @@ class HasPropertiesTest < Minitest::Test
         property :another_one, as: :complex_property, required: true
       end
 
-      assert_equal %i{ complex_property }, parent.required_properties
-      assert_equal %i{ another_one complex_property }, child.new.send(:required_properties).sort
+      assert_equal %i{ complex_property }, parent.required_properties.keys
+      assert_equal %i{ another_one complex_property }, child.new.send(:required_properties).keys.sort
     end
 
     should "inherit the accessors of its superclass" do
@@ -277,16 +277,8 @@ class HasPropertiesTest < Minitest::Test
       @element = Class.new do
         include OpenXml::HasProperties
         property :property_haver_property, required: true
-        value_property :boolean_property, required: true
+        value_property :boolean_property, required: true, default_value: false
 
-        def default_property_value_for(prop)
-          default_value_calls << prop
-          true
-        end
-
-        def default_value_calls
-          @default_value_calls ||= []
-        end
       end
     end
 
@@ -296,9 +288,9 @@ class HasPropertiesTest < Minitest::Test
       assert an_element.instance_variable_defined?(:"@boolean_property")
     end
 
-    should "call #default_property_value_for with each required value property" do
+    should "set the specified default for value properties" do
       an_element = element.new
-      assert_equal %i{ boolean_property }, an_element.default_value_calls
+      assert_equal false, an_element.boolean_property.value
     end
   end
 

--- a/test/has_properties_test.rb
+++ b/test/has_properties_test.rb
@@ -292,27 +292,12 @@ class HasPropertiesTest < Minitest::Test
 
     should "instantiate each required property" do
       an_element = element.new
-      an_element.build_required_properties
       assert an_element.instance_variable_defined?(:"@property_haver_property")
       assert an_element.instance_variable_defined?(:"@boolean_property")
     end
 
-    should "call #build_required_properties in turn on each required property" do
-      an_element = element.new
-      mock = MiniTest::Mock.new
-      mock.expect :build_required_properties, nil
-
-      OpenXml::Properties::PropertyHaverProperty.stub :new, mock do
-        an_element.build_required_properties
-      end
-
-      assert mock.verify
-    end
-
     should "call #default_property_value_for with each required value property" do
       an_element = element.new
-      assert_equal 0, an_element.default_value_calls.count, "Expected default_value_calls to be empty initially"
-      an_element.build_required_properties
       assert_equal %i{ boolean_property }, an_element.default_value_calls
     end
   end


### PR DESCRIPTION
Still no implementation on required attributes or `property_choice` groups. Part of me wants to raise an exception at render if required elements are not defined (including required properties and value properties), but I'm not sure what kind of mechanism should be used to get around that requirement for testing.

There are a few extra fixes that found their way into this branch also. They're pretty small, but I can pull them out into their own PR if necessary.