### PR TITLE
Bumped rubyzip dependency to 1.2.2

### DIFF
--- a/openxml-package.gemspec
+++ b/openxml-package.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubyzip", "~> 1.2.1"
+  spec.add_dependency "rubyzip", "~> 1.2.2"
   spec.add_dependency "nokogiri"
   spec.add_dependency "ox"
 


### PR DESCRIPTION
Updated the rubyzip gem dependency in response to CVE:
https://nvd.nist.gov/vuln/detail/CVE-2018-1000544