### PR TITLE
Optimizations

### DIFF
--- a/lib/openxml/has_attributes.rb
+++ b/lib/openxml/has_attributes.rb
@@ -87,68 +87,69 @@ module OpenXml
       unset_attributes = required_attributes.reject do |attr|
         instance_variable_defined?("@#{attr}")
       end
-      message = "Required attribute(s) #{unset_attributes.join(", ")} have not been set"
-      raise OpenXml::UnmetRequirementError, message if unset_attributes.any?
+      return if unset_attributes.empty?
+
+      raise OpenXml::UnmetRequirementError, "Required attribute(s) #{unset_attributes.join(", ")} have not been set"
     end
 
     def boolean(value)
-      message = "Invalid #{name}: frame must be true or false"
-      raise ArgumentError, message unless [true, false].member? value
+      return if [true, false].member? value
+      raise ArgumentError, "Invalid #{name}: frame must be true or false"
     end
 
     def hex_color(value)
-      message = "Invalid #{name}: must be :auto or a hex color, e.g. 4F1B8C"
-      raise ArgumentError, message unless value == :auto || value =~ /^[0-9A-F]{6}$/
+      return if value == :auto || value =~ /^[0-9A-F]{6}$/
+      raise ArgumentError, "Invalid #{name}: must be :auto or a hex color, e.g. 4F1B8C"
     end
 
     def hex_digit(value)
-      message = "Invalid #{name}: must be a two-digit hex number, e.g. BF"
-      raise ArgumentError, message unless value =~ /^[0-9A-F]{2}$/
+      return if value =~ /^[0-9A-F]{2}$/
+      raise ArgumentError, "Invalid #{name}: must be a two-digit hex number, e.g. BF"
     end
 
     def hex_digit_4(value)
-      message = "Invalid #{name}: must be a four-digit hex number, e.g. BF12"
-      raise ArgumentError, message unless value =~ /^[0-9A-F]{4}$/
+      return if value =~ /^[0-9A-F]{4}$/
+      raise ArgumentError, "Invalid #{name}: must be a four-digit hex number, e.g. BF12"
     end
 
     def long_hex_number(value)
-      message = "Invalid #{name}: must be an eight-digit hex number, e.g., FFAC0013"
-      raise ArgumentError, message unless value =~ /^[0-9A-F]{8}$/
+      return if value =~ /^[0-9A-F]{8}$/
+      raise ArgumentError, "Invalid #{name}: must be an eight-digit hex number, e.g., FFAC0013"
     end
 
     def hex_string(value)
-      message = "Invalid #{name}: must be a string of hexadecimal numbers, e.g. FFA23C6E"
-      raise ArgumentError, message unless value =~ /^[0-9A-F]+$/
+      return if value =~ /^[0-9A-F]+$/
+      raise ArgumentError, "Invalid #{name}: must be a string of hexadecimal numbers, e.g. FFA23C6E"
     end
 
     def integer(value)
-      message = "Invalid #{name}: must be an integer"
-      raise ArgumentError, message unless value.is_a?(Integer)
+      return if value.is_a?(Integer)
+      raise ArgumentError, "Invalid #{name}: must be an integer"
     end
 
     def positive_integer(value)
-      message = "Invalid #{name}: must be a positive integer"
-      raise ArgumentError, message unless value.is_a?(Integer) && value >= 0
+      return if value.is_a?(Integer) && value >= 0
+      raise ArgumentError, "Invalid #{name}: must be a positive integer"
     end
 
     def string(value)
-      message = "Invalid #{name}: must be a string"
-      raise ArgumentError, message if !value.is_a?(String) || value.length.zero?
+      return if value.is_a?(String) && value.length > 0
+      raise ArgumentError, "Invalid #{name}: must be a string"
     end
 
     def string_or_blank(value)
-      message = "Invalid #{name}: must be a string, even if the string is empty"
-      raise ArgumentError, message unless value.is_a?(String)
+      return if value.is_a?(String)
+      raise ArgumentError, "Invalid #{name}: must be a string, even if the string is empty"
     end
 
     def in_range?(value, range)
-      message = "Invalid #{name}: must be a number between #{range.begin} and #{range.end}"
-      raise ArgumentError, message unless range.include?(value.to_i)
+      return if range.include?(value.to_i)
+      raise ArgumentError, "Invalid #{name}: must be a number between #{range.begin} and #{range.end}"
     end
 
     def percentage(value)
-      message = "Invalid #{name}: must be a percentage"
-      raise ArgumentError, message unless value.is_a?(String) && value =~ /-?[0-9]+(\.[0-9]+)?%/ # Regex supplied in sec. 22.9.2.9 of Office Open XML docs
+      return if value.is_a?(String) && value =~ /-?[0-9]+(\.[0-9]+)?%/ # Regex supplied in sec. 22.9.2.9 of Office Open XML docs
+      raise ArgumentError, "Invalid #{name}: must be a percentage"
     end
 
     def on_or_off(value)
@@ -156,13 +157,13 @@ module OpenXml
     end
 
     def valid_in?(value, list)
-      message = "Invalid #{name}: must be one of #{list} (was #{value.inspect})"
-      raise ArgumentError, message unless list.member?(value)
+      return if list.member?(value)
+      raise ArgumentError, "Invalid #{name}: must be one of #{list} (was #{value.inspect})"
     end
 
     def matches?(value, regexp)
-      message = "Value does not match #{regexp}"
-      raise ArgumentError, message unless value =~ regexp
+      return if value =~ regexp
+      raise ArgumentError, "Value does not match #{regexp}"
     end
 
   end

--- a/lib/openxml/has_properties.rb
+++ b/lib/openxml/has_properties.rb
@@ -201,9 +201,8 @@ module OpenXml
 
     def ensure_unique_in_group(name, group_index)
       other_names = (choice_groups[group_index] - [name])
-      unique = other_names.none? { |other_name| instance_variable_defined?("@#{other_name}") }
-      message = "Property #{name} cannot also be set with #{other_names.join(", ")}."
-      raise ChoiceGroupUniqueError, message unless unique
+      return if other_names.none? { |other_name| instance_variable_defined?("@#{other_name}") }
+      raise ChoiceGroupUniqueError, "Property #{name} cannot also be set with #{other_names.join(", ")}."
     end
 
     def unmet_choices
@@ -216,8 +215,8 @@ module OpenXml
 
     def ensure_required_choices
       unmet_choice_groups = unmet_choices.map { |index| choice_groups[index].join(", ") }
-      message = "Required choice from among group(s) (#{unmet_choice_groups.join("), (")}) not made"
-      raise OpenXml::UnmetRequirementError, message if unmet_choice_groups.any?
+      return if unmet_choice_groups.empty?
+      raise OpenXml::UnmetRequirementError, "Required choice from among group(s) (#{unmet_choice_groups.join("), (")}) not made"
     end
 
   end

--- a/lib/openxml/properties/base_property.rb
+++ b/lib/openxml/properties/base_property.rb
@@ -38,8 +38,7 @@ module OpenXml
       def validate_tag(tag)
         return if self.class.allowed_tags.include?(tag)
         allowed = self.class.allowed_tags.join(", ")
-        message = "Invalid tag name for #{name}: #{tag.inspect}. It should be one of #{allowed}."
-        raise ArgumentError, message
+        raise ArgumentError, "Invalid tag name for #{name}: #{tag.inspect}. It should be one of #{allowed}."
       end
 
       def render?


### PR DESCRIPTION
After https://github.com/cph/lsb/pull/1119, I started looking into why it was taking so long to construct a PowerPoint in Builder and tried tweaking this library while exporting a benchmark PowerPoint. The first two commits made no noticeable difference in performance, but the last commit actually cut the time spent in `PptxExporter#generate` down by about 60% (from about 3.8s to about 1.6s).

About _half_ of the remaining 1.6s is spent by `ParagraphMeasurer`. I'd still like to track down the other half.

Also, it takes about 1s to call `Package#to_stream` and most of that is spent in `OpenXml::Builder#method_missing`, it appears.