### PR TITLE
[fix] write_to writes binary both in Unix and Windows

### DIFF
--- a/lib/openxml/package.rb
+++ b/lib/openxml/package.rb
@@ -80,7 +80,7 @@ module OpenXml
     end
 
     def write_to(path)
-      File.open(path, "w") do |file|
+      File.open(path, "wb") do |file|
         file.write to_stream.string
       end
     end


### PR DESCRIPTION
For Windows, `write_to` in [openxml-package/package.rb](https://github.com/openxml/openxml-package/blob/master/lib/openxml/package.rb) should be:

```rb
    def write_to(path)
      File.open(path, "wb") do |file|
        file.write to_stream.string
      end
    end
    alias :save :write_to
```

because the current `write_to` writes a broken docx file that MS Word cannot open correctly.

Note:

- `File.open(path, "w")`: 'text mode' in Windows
- `File.open(path, "wb")`: 'binary mode' in Windows (`b` is ignored in Unix)

Then this fix should not affect to Unix environments.

## Details

Given:

-`xml` (new OOXML string at word/style.xml to be written)
- `docx_path` (file path to input docx)
- `output_path` (file path to output docx)

This code below doesn't work:

```rb
OpenXml::Package.open(docx_path) do |package|
  package.add_part 'word/styles.xml', OpenXml::Parts::UnparsedPart.new(xml)
  package.write_to output_path      
end
```

The new code below works:

```rb
OpenXml::Package.open(docx_path) do |package|
  package.add_part 'word/styles.xml', OpenXml::Parts::UnparsedPart.new(xml)
  File.open(tmp.path, 'wb') do |f|
    f.write package.to_stream.string
  end
end
```
