### PR TITLE
Unpinned rubyzip dependency

### DIFF
--- a/openxml-package.gemspec
+++ b/openxml-package.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubyzip", "~> 1.2.2"
+  spec.add_dependency "rubyzip"
   spec.add_dependency "nokogiri"
   spec.add_dependency "ox"
 


### PR DESCRIPTION
### Summary
This will allow apps depending on this gem to upgrade to the latest, patched version of Rubyzip