### PR TITLE
Replace Travis CI with GitHub Actions for running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Tests
+on: [push]
+
+jobs:
+  ruby:
+    name: Ruby Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: [ "2.3", "2.4", "2.5", "2.6", "2.7", "3.0" ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ${{ matrix.ruby-version }}
+      - name: Run Tests
+        run: bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-# .travis.yml
-language: ruby
-rvm:
-  - 2.3.0
-script:
-  - bundle exec rake test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,10 +6,11 @@ SimpleCov.start do
   add_filter "test/"
 end
 
+require "rr"
+
 require "minitest/reporters/turn_reporter"
 MiniTest::Reporters.use! Minitest::Reporters::TurnReporter.new
 
 require "shoulda/context"
 require "pry"
-require "rr"
 require "minitest/autorun"


### PR DESCRIPTION
- Remove Travis CI configuration
- Add GitHub Actions workflow to test with all compatible Ruby versions
- Avoid errors in rr
