### PR TITLE
Ruby 3.2 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [ "2.3", "2.4", "2.5", "2.6", "2.7", "3.0" ]
+        ruby-version: [ "3.0", "3.1", "3.2", "3.3" ]
 
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ test/version_tmp
 *.o
 *.a
 mkmf.log
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5 - Oct 7, 2024
+
+ - Ruby 3.2 support
+
 ## 0.3.4 - Oct 16, 2019
 
  - Removed rubyzip lock

--- a/lib/openxml-package/version.rb
+++ b/lib/openxml-package/version.rb
@@ -1,3 +1,3 @@
 module OpenXmlPackage
-  VERSION = "0.3.4"
+  VERSION = "0.3.5"
 end

--- a/lib/openxml/has_attributes.rb
+++ b/lib/openxml/has_attributes.rb
@@ -162,7 +162,7 @@ module OpenXml
     end
 
     def matches?(value, regexp)
-      return if value =~ regexp
+      return if value.is_a?(String) && value =~ regexp
       raise ArgumentError, "Value does not match #{regexp}"
     end
 

--- a/test/has_children_test.rb
+++ b/test/has_children_test.rb
@@ -35,7 +35,7 @@ class HasChildrenTest < Minitest::Test
     end
 
     should "call to_xml on all of its children" do
-      child = MiniTest::Mock.new
+      child = Minitest::Mock.new
       child.expect :to_xml, "xml", %w{ xml }
       element << child
       element.to_xml "xml"

--- a/test/has_properties_test.rb
+++ b/test/has_properties_test.rb
@@ -130,9 +130,9 @@ class HasPropertiesTest < Minitest::Test
       end
 
       should "call to_xml on each property" do
-        builder = Nokogiri::XML::Builder.new
-        mock = MiniTest::Mock.new
-        def mock.render?; true; end
+        builder = OpenXml::Builder.new
+        mock = Minitest::Mock.new
+        mock.expect(:render?, true)
         mock.expect(:to_xml, nil, [ builder ])
 
         OpenXml::Properties::BooleanProperty.stub :new, mock do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,7 @@ end
 require "rr"
 
 require "minitest/reporters/turn_reporter"
-MiniTest::Reporters.use! Minitest::Reporters::TurnReporter.new
+Minitest::Reporters.use! Minitest::Reporters::TurnReporter.new
 
 require "shoulda/context"
 require "pry"


### PR DESCRIPTION
Prior to Ruby 3.2, `Object#=~` was defined, but returned `nil`. This meant you could get away with assuming an argument was a string, and it would fail gracefully when you tried to check it against a Regex. Starting in Ruby 3.2, `Object#=~` is no longer defined, so we need to add the check for if the argument is actually a string.